### PR TITLE
♻️ Refactor createMockRepo

### DIFF
--- a/apps/api/src/Routes/AnimalExample/CreateAnimal.test.ts
+++ b/apps/api/src/Routes/AnimalExample/CreateAnimal.test.ts
@@ -1,21 +1,20 @@
 import { createResponseMock, mockRouteHandler, createRequestMock } from "Utils/mockUtils"
 import expectStatus from "Utils/expectStatus"
 
-import getAnimalExampleRepo from "Repository/AnimalExampleRepository.mock"
 import CreateAnimal from "./CreateAnimal"
+import mockAnimalRepo from "Repository/AnimalExampleRepository.mock"
 
 describe('CreateAnimal Route Handler', () => {
 
-  const [ AnimalExampleRepo, RepoConfig ] = getAnimalExampleRepo()
+  // create mockRepo
+  const [ AnimalExampleRepo, repoConfig ] = mockAnimalRepo()
+  // create route
   const createAnimalRoute = CreateAnimal({ AnimalExampleRepo })
-  
-  // reset route and db between tests
-  beforeEach(() => {
-    RepoConfig.resetTable()
-  })
+
+  // reset table inbetween tests
+  beforeEach(() => { repoConfig.resetTable() })
 
   it('correctly saves the animal given in the request body in the database table', async () => {
-    
     const catInfo = {
       name: "Cat",
       rank: 5
@@ -30,14 +29,13 @@ describe('CreateAnimal Route Handler', () => {
     await mockRouteHandler(createAnimalRoute, request, response)
 
     // expect new dog to be saved to table
-    const AnimalExampleTable = RepoConfig.table
+    const AnimalExampleTable = repoConfig.table
     expect(AnimalExampleTable.length).toBe(1)
     expect(AnimalExampleTable[0]).toMatchObject(catEntity)
     
   })
 
   it('correctly returns the new animal in the response json', async () => {
-
     const dogInfo = {
       name: "Cat",
       rank: 25

--- a/apps/api/src/index.test.ts
+++ b/apps/api/src/index.test.ts
@@ -1,13 +1,5 @@
-import { add } from '@labfaz/adder'
-import Middlewares from 'Middlewares'
-
 describe('server', () =>{
 
   test('empty test', () => {
-    const three: number = 3
-    if (typeof Middlewares === 'function') {
-      expect(2).toBe(2)
-    }
-    expect(add(2, 1)).toBe(three)
   })
 })


### PR DESCRIPTION
this fixes #10 

With this refactor, createMockRepo creates a mock of the repository
using spies and mockImplementations over the default repo instead of
mocking everything from scratch and not being able to access the repo's
methods.